### PR TITLE
Modify logging to reduce build size further

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The idea is not new: [Tasmota also uses a SafeBoot partition](https://tasmota.gi
 - [How to build the SafeBoot firmware image](#how-to-build-the-safeboot-firmware-image)
 - [SafeBoot Example](#safeboot-example)
 - [How to reboot in SafeBoot mode from the app](#how-to-reboot-in-safeboot-mode-from-the-app)
+- [Configuration options to manage build size](#configuration-options-to-manage-build-size)
 - [License](#license)
 
 [![](https://mathieu.carbou.me/MycilaSafeBoot/safeboot-ssid.jpeg)](https://mathieu.carbou.me/MycilaSafeBoot/safeboot-ssid.jpeg)
@@ -106,7 +107,7 @@ spiffs   ,data ,spiffs   ,8128K  ,64K   ,
 coredump ,data ,coredump ,8192K  ,64K   ,
 ```
 
-The SafeBoot partition is also automatically booted wen the firmware is missing.
+The SafeBoot partition is also automatically booted when the firmware is missing.
 
 ## How it works
 
@@ -238,3 +239,43 @@ if (partition) {
   return false;
 }
 ```
+
+## Configuration options to manage build size
+
+Squezing everything into the SafeBoot partition (655360 bytes only) is a tight fit especially on ethernet enabled boards.
+
+Disabling the logging capabilites saves about 12 kbytes in the final build. Just comment out `MYCILA_LOGGER_SUPPORT` in `platformio.ini`.
+
+```ini
+; -D MYCILA_LOGGER_SUPPORT
+```
+
+Disabling mDNS saves about 24 kbytes. Enable both [...]_NO_DNS options in `platformio.ini` to reduce the build size:
+
+```ini
+-D ESPCONNECT_NO_MDNS
+-D MYCILA_SAFEBOOT_NO_MDNS
+```
+
+### Options matrix 
+
+| Board                | mDNS: on, logger: on | mDNS: on, logger: off | mDNS: off, logger: off |
+| -------------------- | -------------------- | --------------------- | ---------------------- |
+| denky_d4             | FAILED               | OK                    | OK                     |
+| esp32-c3-devkitc-02  | OK                   | OK                    | OK                     |
+| esp32-c6-devkitc-1   | FAILED               | FAILED                | OK                     |
+| esp32-gateway        | FAILED               | OK                    | OK                     |
+| esp32-poe-iso        | FAILED               | FAILED                | OK                     |
+| esp32-poe            | FAILED               | FAILED                | OK                     |
+| esp32-s2-saola-1     | OK                   | OK                    | OK                     |
+| esp32-s3-devkitc-1   | OK                   | OK                    | OK                     |
+| esp32-solo1          | OK                   | OK                    | OK                     |
+| esp32dev             | OK                   | OK                    | OK                     |
+| esp32s3box           | OK                   | OK                    | OK                     |
+| tinypico             | FAILED               | OK                    | OK                     |
+| wipy3                | FAILED               | OK                    | OK                     |
+| wt32-eth01           | FAILED               | FAILED                | OK                     |
+| lilygo-t-eth-lite-s3 | OK                   | OK                    | OK                     |
+| wemos_d1_uno32       | OK                   | OK                    | OK                     |
+| lolin_s2_mini        | OK                   | OK                    | OK                     |
+| esp32_s3_tiny        | OK                   | OK                    | OK                     |

--- a/boards/lolin_s2_mini.json
+++ b/boards/lolin_s2_mini.json
@@ -1,0 +1,47 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s2_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_LOLIN_S2_MINI",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x80C2"
+      ]
+    ],
+    "mcu": "esp32s2",
+    "variant": "lolin_s2_mini"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s2.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "WEMOS LOLIN S2 Mini",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.wemos.cc/en/latest/s2/s2_mini.html",
+  "vendor": "WEMOS"
+}

--- a/boards/waveshare_esp32_s3_tiny.json
+++ b/boards/waveshare_esp32_s3_tiny.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "waveshare_esp32_s3_tiny",
+    "variants_dir": "variants"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "ESP32-S3-Tiny",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.waveshare.com/wiki/ESP32-S3-Tiny",
+  "vendor": "Waveshare"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ lib_deps =
   Update
   WebServer
   mathieucarbou/MycilaESPConnect @ 8.0.0
-  ; mathieucarbou/MycilaLogger @ 3.3.0
+  mathieucarbou/MycilaLogger @ 3.3.0
 lib_ignore =
   ArduinoJson
   AsyncTCP
@@ -36,10 +36,10 @@ build_flags =
   ; ESPConnect
   -D ESPCONNECT_NO_CAPTIVE_PORTAL
   -D ESPCONNECT_NO_STD_STRING
-  ; -D ESPCONNECT_NO_MDNS
+  -D ESPCONNECT_NO_MDNS
   ; Mycila
-  ; -D MYCILA_SAFEBOOT_NO_MDNS
-  ; -D MYCILA_LOGGER_SUPPORT
+  -D MYCILA_SAFEBOOT_NO_MDNS
+  -D MYCILA_LOGGER_SUPPORT
   ; Arduino
   -D HTTPCLIENT_NOSECURE
   -D UPDATE_NOCRYPT

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,3 +140,9 @@ build_flags =
 
 [env:wemos_d1_uno32]
 board = wemos_d1_uno32
+
+[env:lolin_s2_mini]
+board = lolin_s2_mini
+
+[env:esp32_s3_tiny]
+board = waveshare_esp32_s3_tiny

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 name = SafeBoot
-default_envs = esp32dev, denky_d4, esp32-c3-devkitc-02, esp32-c6-devkitc-1, esp32-gateway, esp32-poe-iso, esp32-poe, esp32-s2-saola-1, esp32-s3-devkitc-1, esp32-solo1, esp32dev, esp32s3box, tinypico, wipy3, wt32-eth01, lilygo-t-eth-lite-s3, wemos_d1_uno32
+default_envs = esp32dev, denky_d4, esp32-c3-devkitc-02, esp32-c6-devkitc-1, esp32-gateway, esp32-poe-iso, esp32-poe, esp32-s2-saola-1, esp32-s3-devkitc-1, esp32-solo1, esp32dev, esp32s3box, tinypico, wipy3, wt32-eth01, lilygo-t-eth-lite-s3, wemos_d1_uno32, lolin_s2_mini, esp32_s3_tiny
 
 [env]
 framework = arduino
@@ -23,11 +23,11 @@ monitor_speed = 115200
 lib_compat_mode = strict
 lib_ldf_mode = chain
 lib_deps =
-  ; ESPmDNS
+  ESPmDNS
   Update
   WebServer
   mathieucarbou/MycilaESPConnect @ 8.0.0
-  mathieucarbou/MycilaLogger @ 3.3.0
+  ; mathieucarbou/MycilaLogger @ 3.3.0
 lib_ignore =
   ArduinoJson
   AsyncTCP
@@ -36,10 +36,10 @@ build_flags =
   ; ESPConnect
   -D ESPCONNECT_NO_CAPTIVE_PORTAL
   -D ESPCONNECT_NO_STD_STRING
-  -D ESPCONNECT_NO_MDNS
+  ; -D ESPCONNECT_NO_MDNS
   ; Mycila
-  -D MYCILA_SAFEBOOT_NO_MDNS
-  -D MYCILA_LOGGER_SUPPORT
+  ; -D MYCILA_SAFEBOOT_NO_MDNS
+  ; -D MYCILA_LOGGER_SUPPORT
   ; Arduino
   -D HTTPCLIENT_NOSECURE
   -D UPDATE_NOCRYPT

--- a/variants/waveshare_esp32_s3_tiny/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_tiny/pins_arduino.h
@@ -1,0 +1,87 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID          0x303a
+#define USB_PID          0x1001
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Tiny"
+#define USB_SERIAL       ""  // Empty string for MAC address
+
+#define MTDO 45
+#define MTDI 47
+#define MTMS 48
+#define MTCK 44
+
+// UART0 pins
+static const uint8_t TX = 49;
+static const uint8_t RX = 50;
+
+static const uint8_t SDA = -1;
+static const uint8_t SCL = -1;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 32;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 34;  // FSPIQ
+static const uint8_t SCK = 33;   // FSPICLK
+
+//static const uint8_t XTAL_32K_N = 22;
+//static const uint8_t XTAL_32K_P = 21;
+
+//static const uint8_t SPIWP = 31;
+//static const uint8_t SPIHD = 30;
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t GPIO1 = 1;
+static const uint8_t GPIO2 = 2;
+static const uint8_t GPIO3 = 3;
+static const uint8_t GPIO4 = 4;
+static const uint8_t GPIO5 = 5;
+static const uint8_t GPIO6 = 6;
+static const uint8_t GPIO7 = 7;
+static const uint8_t GPIO8 = 8;
+static const uint8_t GPIO9 = 9;
+static const uint8_t GPIO10 = 10;
+static const uint8_t GPIO11 = 11;
+static const uint8_t GPIO12 = 12;
+static const uint8_t GPIO13 = 13;
+static const uint8_t GPIO14 = 14;
+static const uint8_t GPIO15 = 15;
+static const uint8_t GPIO16 = 16;
+static const uint8_t GPIO17 = 17;
+static const uint8_t GPIO18 = 18;
+
+static const uint8_t GPIO21 = 21;
+
+static const uint8_t GPIO33 = 33;
+static const uint8_t GPIO34 = 34;
+static const uint8_t GPIO35 = 35;
+static const uint8_t GPIO36 = 36;
+static const uint8_t GPIO37 = 37;
+static const uint8_t GPIO38 = 38;
+static const uint8_t GPIO39 = 39;
+static const uint8_t GPIO40 = 40;
+static const uint8_t GPIO41 = 41;
+static const uint8_t GPIO42 = 42;
+
+static const uint8_t GPIO45 = 45;
+
+static const uint8_t GPIO47 = 47;
+static const uint8_t GPIO48 = 48;
+
+static const uint8_t RGB_DATA = 38;
+
+#define PIN_RGB_LED RGB_DATA
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
- Modified the logging code in main.cpp to exclude it thoroughly from the build (and saving 12 kbytes) when logger support is disabled (i.e. `; -D MYCILA_LOGGER_SUPPORT` is commented out in `platformio.ini`).
- Added test results with different options to the README.md
- Also, I took the liberty to add my favorite boards