### PR TITLE
Contributions from @soylentOrange:

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,12 @@ jobs:
             "esp32-solo1",
             "esp32dev",
             "esp32s3box",
+            "lilygo-t-eth-lite-s3",
+            "lolin_s2_mini",
             "tinypico",
+            "wemos_d1_uno32",
             "wipy3",
             "wt32-eth01",
-            "lilygo-t-eth-lite-s3",
-            "wemos_d1_uno32"
           ]
     steps:
       - name: Checkout
@@ -96,11 +97,11 @@ jobs:
             "esp32-solo1",
             "esp32dev",
             "esp32s3box",
+            "lolin_s2_mini",
             "tinypico",
+            "wemos_d1_uno32",
             "wipy3",
             "wt32-eth01",
-            # "lilygo-t-eth-lite-s3",
-            # "wemos_d1_uno32"
           ]
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.pio
 /.vscode
 /logs
+
+/sdkconfig.defaults

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The idea is not new: [Tasmota also uses a SafeBoot partition](https://tasmota.gi
 - [How to build the SafeBoot firmware image](#how-to-build-the-safeboot-firmware-image)
 - [SafeBoot Example](#safeboot-example)
 - [How to reboot in SafeBoot mode from the app](#how-to-reboot-in-safeboot-mode-from-the-app)
-- [License](#license)
+- [Configuration options to manage build size](#configuration-options-to-manage-build-size)
 
 [![](https://mathieu.carbou.me/MycilaSafeBoot/safeboot-ssid.jpeg)](https://mathieu.carbou.me/MycilaSafeBoot/safeboot-ssid.jpeg)
 
@@ -106,7 +106,7 @@ spiffs   ,data ,spiffs   ,8128K  ,64K   ,
 coredump ,data ,coredump ,8192K  ,64K   ,
 ```
 
-The SafeBoot partition is also automatically booted wen the firmware is missing.
+The SafeBoot partition is also automatically booted when the firmware is missing.
 
 ## How it works
 
@@ -238,3 +238,42 @@ if (partition) {
   return false;
 }
 ```
+
+## Configuration options to manage build size
+
+Squezing everything into the SafeBoot partition (655360 bytes only) is a tight fit especially on ethernet enabled boards.
+
+Disabling the logging capabilites saves about 12 kbytes in the final build. Just comment out `MYCILA_LOGGER_SUPPORT` in `platformio.ini`.
+
+```ini
+; -D MYCILA_LOGGER_SUPPORT
+```
+
+Disabling mDNS saves about 24 kbytes. Enable both [...]\_NO_DNS options in `platformio.ini` to reduce the build size:
+
+```ini
+-D ESPCONNECT_NO_MDNS
+-D MYCILA_SAFEBOOT_NO_MDNS
+```
+
+### Options matrix
+
+| Board                | mDNS: on, logger: on | mDNS: on, logger: off | mDNS: off, logger: off |
+| -------------------- | -------------------- | --------------------- | ---------------------- |
+| denky_d4             | FAILED               | OK                    | OK                     |
+| esp32-c3-devkitc-02  | OK                   | OK                    | OK                     |
+| esp32-c6-devkitc-1   | FAILED               | FAILED                | OK                     |
+| esp32-gateway        | FAILED               | OK                    | OK                     |
+| esp32-poe            | FAILED               | FAILED                | OK                     |
+| esp32-poe-iso        | FAILED               | FAILED                | OK                     |
+| esp32-s2-saola-1     | OK                   | OK                    | OK                     |
+| esp32-s3-devkitc-1   | OK                   | OK                    | OK                     |
+| esp32-solo1          | OK                   | OK                    | OK                     |
+| esp32dev             | OK                   | OK                    | OK                     |
+| esp32s3box           | OK                   | OK                    | OK                     |
+| lilygo-t-eth-lite-s3 | OK                   | OK                    | OK                     |
+| lolin_s2_mini        | OK                   | OK                    | OK                     |
+| tinypico             | FAILED               | OK                    | OK                     |
+| wemos_d1_uno32       | OK                   | OK                    | OK                     |
+| wipy3                | FAILED               | OK                    | OK                     |
+| wt32-eth01           | FAILED               | FAILED                | OK                     |

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 name = SafeBoot
-default_envs = esp32dev, denky_d4, esp32-c3-devkitc-02, esp32-c6-devkitc-1, esp32-gateway, esp32-poe-iso, esp32-poe, esp32-s2-saola-1, esp32-s3-devkitc-1, esp32-solo1, esp32dev, esp32s3box, tinypico, wipy3, wt32-eth01, lilygo-t-eth-lite-s3, wemos_d1_uno32
+default_envs = esp32dev, denky_d4, esp32-c3-devkitc-02, esp32-c6-devkitc-1, esp32-gateway, esp32-poe-iso, esp32-poe, esp32-s2-saola-1, esp32-s3-devkitc-1, esp32-solo1, esp32dev, esp32s3box, lolin_s2_mini, tinypico, wipy3, wt32-eth01, lilygo-t-eth-lite-s3, wemos_d1_uno32
 
 [env]
 framework = arduino
@@ -23,7 +23,7 @@ monitor_speed = 115200
 lib_compat_mode = strict
 lib_ldf_mode = chain
 lib_deps =
-  ; ESPmDNS
+  ESPmDNS
   Update
   WebServer
   mathieucarbou/MycilaESPConnect @ 8.0.0
@@ -36,14 +36,17 @@ build_flags =
   ; ESPConnect
   -D ESPCONNECT_NO_CAPTIVE_PORTAL
   -D ESPCONNECT_NO_STD_STRING
-  -D ESPCONNECT_NO_MDNS
-  ; Mycila
-  -D MYCILA_SAFEBOOT_NO_MDNS
-  -D MYCILA_LOGGER_SUPPORT
   ; Arduino
   -D HTTPCLIENT_NOSECURE
   -D UPDATE_NOCRYPT
-  -D CONFIG_ARDUHAL_LOG_COLORS
+  ; ------------------------------
+  ; mDNS ON by default 
+  ; -D ESPCONNECT_NO_MDNS
+  ; -D MYCILA_SAFEBOOT_NO_MDNS
+  ; ------------------------------
+  ; Logging OFF by default
+  ; -D MYCILA_LOGGER_SUPPORT
+  ; ------------------------------
   ; C++
   -Wall -Wextra
   -std=c++17
@@ -69,9 +72,16 @@ board = denky_d4
 
 [env:esp32-c3-devkitc-02]
 board = esp32-c3-devkitc-02
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
 
 [env:esp32-c6-devkitc-1]
 board = esp32-c6-devkitc-1
+build_flags =
+  ${env.build_flags}
+  -D ESPCONNECT_NO_MDNS
+  -D MYCILA_SAFEBOOT_NO_MDNS
 
 [env:esp32-gateway]
 board = esp32-gateway
@@ -84,6 +94,8 @@ build_flags =
 board = esp32-poe-iso
 build_flags =
   ${env.build_flags}
+  -D ESPCONNECT_NO_MDNS
+  -D MYCILA_SAFEBOOT_NO_MDNS
   -D ESPCONNECT_ETH_RESET_ON_START
   -D ESPCONNECT_ETH_SUPPORT
 
@@ -91,43 +103,46 @@ build_flags =
 board = esp32-poe
 build_flags =
   ${env.build_flags}
+  -D ESPCONNECT_NO_MDNS
+  -D MYCILA_SAFEBOOT_NO_MDNS
   -D ESPCONNECT_ETH_RESET_ON_START
   -D ESPCONNECT_ETH_SUPPORT
 
 [env:esp32-s2-saola-1]
 board = esp32-s2-saola-1
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
 
 [env:esp32-s3-devkitc-1]
 board = esp32-s3-devkitc-1
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
 
 [env:esp32-solo1]
 board = esp32-solo1
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
 
 [env:esp32dev]
 board = esp32dev
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
 
 [env:esp32s3box]
 board = esp32s3box
-
-[env:tinypico]
-board = tinypico
-
-[env:wipy3]
-board = wipy3
-
-[env:wt32-eth01]
-board = wt32-eth01
 build_flags =
   ${env.build_flags}
-  -D ESPCONNECT_ETH_RESET_ON_START
-  -D ESPCONNECT_ETH_SUPPORT
-  -D ETH_PHY_ADDR=1
-  -D ETH_PHY_POWER=16
+  -D MYCILA_LOGGER_SUPPORT
 
 [env:lilygo-t-eth-lite-s3]
 board = esp32s3box
 build_flags =
   ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
   -D ESPCONNECT_ETH_SUPPORT
   -D ETH_PHY_ADDR=1
   -D ETH_PHY_CS=9
@@ -138,5 +153,31 @@ build_flags =
   -D ETH_PHY_SPI_SCK=10
   -D ETH_PHY_TYPE=ETH_PHY_W5500
 
+[env:lolin_s2_mini]
+board = lolin_s2_mini
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
+
+[env:tinypico]
+board = tinypico
+
 [env:wemos_d1_uno32]
 board = wemos_d1_uno32
+build_flags =
+  ${env.build_flags}
+  -D MYCILA_LOGGER_SUPPORT
+
+[env:wipy3]
+board = wipy3
+
+[env:wt32-eth01]
+board = wt32-eth01
+build_flags =
+  ${env.build_flags}
+  -D ESPCONNECT_NO_MDNS
+  -D MYCILA_SAFEBOOT_NO_MDNS
+  -D ESPCONNECT_ETH_RESET_ON_START
+  -D ESPCONNECT_ETH_SUPPORT
+  -D ETH_PHY_ADDR=1
+  -D ETH_PHY_POWER=16

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,18 +7,29 @@
 #include <HTTPUpdateServer.h>
 #include <HardwareSerial.h>
 #include <MycilaESPConnect.h>
-#include <MycilaLogger.h>
+
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
 
 #ifndef MYCILA_SAFEBOOT_NO_MDNS
   #include <ESPmDNS.h>
 #endif
 
-#include <esp_ota_ops.h>
-#include <esp_partition.h>
+#ifdef MYCILA_LOGGER_SUPPORT
+  #include <MycilaLogger.h>
+Mycila::Logger logger;
+  #define LOGD(tag, format, ...) logger.debug(tag, format, ##__VA_ARGS__)
+  #define LOGI(tag, format, ...) logger.info(tag, format, ##__VA_ARGS__)
+  #define LOGW(tag, format, ...) logger.warn(tag, format, ##__VA_ARGS__)
+  #define LOGE(tag, format, ...) logger.error(tag, format, ##__VA_ARGS__)
+#else
+  #define LOGD(tag, format, ...)
+  #define LOGI(tag, format, ...)
+  #define LOGW(tag, format, ...)
+  #define LOGE(tag, format, ...)
+#endif
 
 #define TAG "SafeBoot"
-
-Mycila::Logger logger;
 
 static WebServer webServer(80);
 static HTTPUpdateServer httpUpdater;
@@ -37,21 +48,23 @@ static String getChipIDStr() {
 }
 
 void setup() {
+#ifdef MYCILA_LOGGER_SUPPORT
   Serial.begin(115200);
-#if ARDUINO_USB_CDC_ON_BOOT
+  #if ARDUINO_USB_CDC_ON_BOOT
   Serial.setTxTimeoutMs(0);
   delay(100);
-#else
+  #else
   while (!Serial)
     yield();
-#endif
+  #endif
 
   logger.forwardTo(&Serial);
   logger.setLevel(ARDUHAL_LOG_LEVEL_DEBUG);
+#endif
 
   // Init hostname
   hostname = "SafeBoot-" + getChipIDStr();
-  logger.info(TAG, "Hostname: %s", hostname.c_str());
+  LOGI(TAG, "Hostname: %s", hostname.c_str());
 
   // Set next boot partition
   const esp_partition_t* partition = esp_partition_find_first(esp_partition_type_t::ESP_PARTITION_TYPE_APP, esp_partition_subtype_t::ESP_PARTITION_SUBTYPE_APP_OTA_0, nullptr);
@@ -85,7 +98,7 @@ void setup() {
 
   espConnect.listen([](Mycila::ESPConnect::State previous, Mycila::ESPConnect::State state) {
     if (state == Mycila::ESPConnect::State::NETWORK_TIMEOUT) {
-      logger.warn(TAG, "Connect timeout! Starting AP mode instead...");
+      LOGW(TAG, "Connect timeout! Starting AP mode instead...");
       // if ETH DHCP times out, we start AP mode
       espConnectConfig.apMode = true;
       espConnect.setConfig(espConnectConfig);
@@ -95,15 +108,15 @@ void setup() {
   // connect...
   espConnect.begin(hostname.c_str(), hostname.c_str(), "", espConnectConfig);
 
-  logger.info(TAG, "Connected to network!");
-  logger.info(TAG, "IP Address: %s", espConnect.getIPAddress().toString().c_str());
-  logger.info(TAG, "Hostname: %s", espConnect.getHostname().c_str());
+  LOGI(TAG, "Connected to network!");
+  LOGI(TAG, "IP Address: %s", espConnect.getIPAddress().toString().c_str());
+  LOGI(TAG, "Hostname: %s", espConnect.getHostname().c_str());
   if (espConnect.getWiFiSSID().length()) {
-    logger.info(TAG, "WiFi SSID: %s", espConnect.getWiFiSSID().c_str());
+    LOGI(TAG, "WiFi SSID: %s", espConnect.getWiFiSSID().c_str());
   }
 
   // starte http
-  logger.info(TAG, "Starting HTTP server...");
+  LOGI(TAG, "Starting HTTP server...");
   webServer.begin();
 
 #ifndef MYCILA_SAFEBOOT_NO_MDNS
@@ -113,13 +126,13 @@ void setup() {
 #endif
 
   // Start OTA
-  logger.info(TAG, "Starting OTA server...");
+  LOGI(TAG, "Starting OTA server...");
   ArduinoOTA.setHostname(hostname.c_str());
   ArduinoOTA.setRebootOnSuccess(true);
   ArduinoOTA.setMdnsEnabled(true);
   ArduinoOTA.begin();
 
-  logger.info(TAG, "Done!");
+  LOGI(TAG, "Done!");
 }
 
 void loop() {


### PR DESCRIPTION
- Add support for lolin_s2_mini & waveshare_esp32_s3_tiny
- Modifiy logging
- Modify logging in main.cpp to switch it off completely and save more space
- Added details on build size
- Tested configurations of options vs. build size

PR Cleanup by @mathieucarbou:
- Adding board lolin_s2_mini to CI
- Removing customizations (should not impact for safeboot image - default board should be compatible)
- Cleaned up main.cpp
- Sorted table
- Reworked pio file to setup sensible defaults for each generated images